### PR TITLE
Add ssh command for WP-CLI to quickly connect to an environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Deployments should be done by calling the wrapper script:
 sh deploy.sh <environment>
 ```
 
+To quickly connect to a server, run the following WP-CLI command:
+
+```
+wp ssh <environment> [--server=<number>]
+```
+
 ## Under the hood
 
 This scaffold is inspired by:

--- a/lib/Cli/Commands/Ssh.php
+++ b/lib/Cli/Commands/Ssh.php
@@ -1,0 +1,67 @@
+<?php namespace Grrr\Root\Cli\Commands;
+
+use WP_CLI;
+use Grrr\Root\Deploy;
+use Garp\Functional as f;
+
+/**
+ * Quickly connect to a server configured a Capistrano deploy task.
+ */
+class Ssh {
+
+    protected $_command = 'ssh';
+    protected $_config = [
+        'shortdesc' => 'Quickly connect to a server configured in one of the deploy tasks.',
+        'synopsis' => [
+            [
+                'type'        => 'positional',
+                'name'        => 'environment',
+                'description' => 'The environment to connect to.',
+                'optional'    => false,
+                'repeating'   => false,
+            ],
+            [
+                'type'        => 'assoc',
+                'name'        => 'server',
+                'description' => 'The server number to connect to.',
+                'optional'    => true,
+                'default'     => 1,
+            ],
+        ],
+        'when' => 'after_wp_load',
+        'longdesc' => '## EXAMPLES' . "\n\n" . 'wp ssh staging',
+    ];
+
+    public function register() {
+        WP_CLI::add_command($this->_command, [$this, 'connect'], $this->_config);
+    }
+
+    public function connect($args, $assoc_args) {
+        $environment = f\prop(0, $args);
+        $server_index = f\prop('server', $assoc_args) ?: 1;
+
+        $config = new Deploy\Config();
+
+        $params = $config->get_params($environment);
+        if (!$params) {
+            WP_CLI::error("No settings found for environment '{$environment}'.");
+            return false;
+        }
+
+        $server = f\prop_in(['server', $server_index - 1], $params);
+        if (!$server) {
+            WP_CLI::error("It seems server '{$server_index}' is not configured.");
+            return false;
+        }
+
+        $this->_execute_ssh_command($server, f\prop('user', $params));
+    }
+
+    protected function _execute_ssh_command($server, $user) {
+        passthru(
+            'ssh ' . escapeshellarg($user) .
+            '@' . escapeshellarg($server)
+        );
+    }
+
+}

--- a/lib/Cli/Setup.php
+++ b/lib/Cli/Setup.php
@@ -1,0 +1,13 @@
+<?php namespace Grrr\Root\Cli;
+
+class Setup {
+
+    public static function init() {
+        if (!defined('WP_CLI') || !WP_CLI) {
+            return;
+        }
+
+        (new Commands\Ssh)->register();
+    }
+
+}

--- a/lib/Deploy/Config.php
+++ b/lib/Deploy/Config.php
@@ -1,0 +1,112 @@
+<?php namespace Grrr\Root\Deploy;
+
+use Garp\Functional as f;
+
+/**
+ * Represents a Capistrano deploy configuration.
+ * Note: this was originally taken from Garp 3.
+ */
+class Config {
+
+    const GENERIC_CONFIG_PATH = '/config/deploy.rb';
+    const ENV_CONFIG_PATH = '/config/deploy/';
+
+    protected $_generic_content;
+
+    protected $_deploy_params = [
+        'server',
+        'deploy_to',
+        'user',
+        'application',
+        'repo_url',
+        'branch',
+    ];
+
+    public function __construct() {
+        $this->_generic_content = $this->_fetch_generic_content();
+    }
+
+    /**
+     * Returns the deploy parameters for a specific environment.
+     *
+     * @param String $env The environment to get parameters for (i.e. 'staging').
+     * @return Array List of deploy parameters (i.e. 'server', 'user', 'deploy_to').
+     */
+    public function get_params(string $env): array {
+        $generic_params = $this->_parse_content($this->_generic_content);
+        $env_params = $this->_parse_content($this->_fetch_env_content($env));
+
+        return f\concat($generic_params, $env_params);
+    }
+
+    /**
+     * Parses the generic configuration.
+     *
+     * @param String $content
+     * @return Array
+     */
+    protected function _parse_content(string $content): array {
+        $output = [];
+        $matches = [];
+        $paramsString = implode('|', $this->_deploy_params);
+        $pattern = '/:?(?P<paramName>' . $paramsString
+            . ')[,:]? [\'"](?P<paramValue>[^\'"]*)[\'"]/';
+
+        if (!preg_match_all($pattern, $content, $matches)) {
+            throw new Exception(
+                "Could not extract deploy parameters from "
+                . self::GENERIC_CONFIG_PATH
+            );
+        }
+
+        foreach ($this->_deploy_params as $p) {
+            $indices = f\keys(
+                array_filter(
+                    $matches['paramName'], function ($pn) use ($p) {
+                        return $pn === $p;
+                    }
+                )
+            );
+            if (!count($indices)) {
+                continue;
+            }
+            $output[$p] = array_values(f\pick($indices, f\prop('paramValue', $matches)));
+
+            // Treat the server param as array (since it's common for it to be
+            // an array, in the case of a multi-server setup).
+            if ($p !== 'server') {
+                $output[$p] = f\prop_in([$p, 0], $output);
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Returns the raw content of the Capistrano
+     * deploy configuration (in Ruby) per environment.
+     *
+     * @param String $env Environment (i.e. 'staging') of which to retrieve config params.
+     * @return String The raw contents of the Capistrano deploy configuration file.
+     */
+    protected function _fetch_env_content(string $env): string {
+        $env_path = $this->_create_path_from_env($env);
+        $env_config = file_get_contents($env_path);
+
+        if ($env_config === false) {
+            throw new Exception(
+                "Could not read the configuration file for the '{$env}' environment."
+            );
+        }
+
+        return $env_config;
+    }
+
+    protected function _create_path_from_env($env) {
+        return realpath(ABSPATH . '/../../' . self::ENV_CONFIG_PATH . $env . '.rb');
+    }
+
+    protected function _fetch_generic_content() {
+        return file_get_contents(realpath(ABSPATH . '/../../' . self::GENERIC_CONFIG_PATH));
+    }
+}

--- a/lib/Sentry.php
+++ b/lib/Sentry.php
@@ -1,6 +1,4 @@
-<?php
-
-namespace Grrr\Root;
+<?php namespace Grrr\Root;
 
 class Sentry {
 

--- a/lib/Versioning.php
+++ b/lib/Versioning.php
@@ -1,6 +1,4 @@
-<?php
-
-namespace Grrr\Root;
+<?php namespace Grrr\Root;
 
 class Versioning {
 

--- a/web/app/themes/wordpress-scaffold/functions.php
+++ b/web/app/themes/wordpress-scaffold/functions.php
@@ -1,11 +1,12 @@
 <?php
 
 use Grrr\Acf;
-use Grrr\API;
-use Grrr\Twig;
-use Grrr\Theme;
-use Grrr\Taxonomies;
+use Grrr\Api;
+use Grrr\Cli;
 use Grrr\PostTypes;
+use Grrr\Taxonomies;
+use Grrr\Theme;
+use Grrr\Twig;
 
 /**
  * Utils.
@@ -26,9 +27,7 @@ if (class_exists('Timber')) {
 /**
  * Advanced Custom Fields.
  */
-if (class_exists('acf')) {
-    (new Acf\Setup)->register();
-}
+(new Acf\Setup)->register();
 
 /**
  * Taxonomies.
@@ -47,3 +46,8 @@ if (class_exists('acf')) {
  * API.
  */
 (new Api\Newsletter)->register();
+
+/**
+ * WP-CLI.
+ */
+(new Cli\Setup)->register();

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Acf/Setup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Acf/Setup.php
@@ -3,6 +3,10 @@
 class Setup {
 
     public function register() {
+        if (!class_exists('acf')) {
+            return;
+        }
+
         (new SyncWarning)->register();
         (new Options\Theme)->register();
         (new FlexibleContent\AdminTitles)->register();

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Cli/Setup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Cli/Setup.php
@@ -1,0 +1,11 @@
+<?php namespace Grrr\Cli;
+
+class Setup {
+
+    public function register() {
+        if (!defined('WP_CLI') || !WP_CLI) {
+            return;
+        }
+    }
+
+}

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -11,3 +11,4 @@ require_once(dirname(__DIR__) . '/config/application.php');
 require_once(ABSPATH . 'wp-settings.php');
 
 \Grrr\Root\Sentry::init();
+\Grrr\Root\Cli\Setup::init();


### PR DESCRIPTION
A command to quickly connect to a server/environment. Defaults to server 1.

```shell
usage: wp ssh <environment> [--server=<server>]
```

Note: most code was taken from [Garp](https://github.com/grrr-amsterdam/garp3/), especially `Grrr\Deploy\Config`. Removed unused code and refactored here and there.