### PR TITLE
Disable fatal error handler for all environments

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -3,3 +3,4 @@
 define('SAVEQUERIES', true);
 define('WP_DEBUG', true);
 define('SCRIPT_DEBUG', true);
+define('WP_DISABLE_FATAL_ERROR_HANDLER', true);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -3,5 +3,6 @@
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
 /** Disable all file modifications including updates and update notifications */
 define('DISALLOW_FILE_MODS', true);

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -3,5 +3,6 @@
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
 /** Disable all file modifications including updates and update notifications */
 define('DISALLOW_FILE_MODS', true);


### PR DESCRIPTION
This should prevent sending out e-mails to everyone for every PHP/template error encountered. In development we're not needing this because we have eyes, on staging/production we're using Sentry.

See: https://make.wordpress.org/core/2019/04/16/fatal-error-recovery-mode-in-5-2/

---

![Screenshot 2019-07-03 at 17 03 06](https://user-images.githubusercontent.com/1607628/60602643-7a1e7000-9db4-11e9-91a7-47fe1b6ce1d1.png)
