### PR TITLE
Make WP-CLI available on the server in the root of the project

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,6 +19,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push(
 # Linked files
 set :linked_files, fetch(:linked_files, []).push(
   '.env',
+  'wp',
   'web/.htaccess',
   'web/app/advanced-cache.php',
   'web/app/db.php'

--- a/config/deploy/tasks/wp-cli.cap
+++ b/config/deploy/tasks/wp-cli.cap
@@ -6,9 +6,10 @@ namespace :wp_cli do
       upload! 'config/deploy/scripts/install-wp-cli.sh',
         "#{shared_path}"
       within shared_path do
-        execute :chmod, '+x', 'install-wp-cli.sh'
+        execute :chmod, '+x install-wp-cli.sh'
         execute :sh, 'install-wp-cli.sh'
-        execute :chmod, '+x', 'wp-cli.phar'
+        execute :mv, 'wp-cli.phar wp'
+        execute :chmod, '+x wp'
         execute :rm, 'install-wp-cli.sh'
       end
     end


### PR DESCRIPTION
This allows you to run `php wp <command>` in the root of the project with the right context.