### PR TITLE
Don't print w3tc comment if w3tc itself dont want to print it

### DIFF
--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Cleanup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Cleanup.php
@@ -51,7 +51,10 @@ add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\wpdocs_dequeue_dashicon');
 /**
  * Disable W3TC footer comment for everyone but Admins.
  */
-function disable_w3tc_comment() {
+function disable_w3tc_comment($can_print_comment) {
+    if (!$can_print_comment) {
+        return false;
+    }
     return current_user_can('activate_plugins');
 }
 add_filter('w3tc_can_print_comment', __NAMESPACE__ . '\\disable_w3tc_comment');


### PR DESCRIPTION
Since the initial value in the filter is as followed:
```
Util_Content::is_html_xml( $buffer ) && !defined( 'DOING_AJAX' )
```