### PR TITLE
Add default focus-ring for focus-visible states

### DIFF
--- a/web/app/themes/wordpress-scaffold/assets/scripts/main.js
+++ b/web/app/themes/wordpress-scaffold/assets/scripts/main.js
@@ -1,6 +1,7 @@
 // Import libraries and polyfills
 import Promise from 'promise-polyfill';
 import 'whatwg-fetch';
+import 'focus-visible';
 import 'classlist-polyfill';
 import { handle, enhance } from '@grrr/hansel';
 import rafPolyfill from './polyfills/request-animation-frame';

--- a/web/app/themes/wordpress-scaffold/assets/styles/base.scss
+++ b/web/app/themes/wordpress-scaffold/assets/styles/base.scss
@@ -101,9 +101,7 @@ label {
  */
 a {
     color: inherit; text-decoration: underline;
-    // sass-lint:disable no-misspelled-properties
     text-decoration-skip-ink: auto;
-    // sass-lint:enable no-misspelled-properties
 }
 a:hover,
 a:focus {

--- a/web/app/themes/wordpress-scaffold/assets/styles/modules/focus-ring.scss
+++ b/web/app/themes/wordpress-scaffold/assets/styles/modules/focus-ring.scss
@@ -1,0 +1,30 @@
+/*
+ * Only applies when non-pointer or non-touch focus is received, and falls
+ * back to default browser focus styling when not supported.
+ *
+ * A `focus-visible` polyfill is used for unsupported platforms, although
+ * it applies the classes to supported platforms as well, leaving the platform
+ * styles for `no-js` scenarios.
+ */
+:focus:not(:focus-visible) {
+    outline: none;
+}
+:focus:not(:-moz-focusring) {
+    outline: none;
+}
+.js-focus-visible :focus:not(.focus-visible) {
+    outline: none;
+}
+
+:focus-visible {
+    outline: $focus-ring;
+}
+:-moz-focusring {
+    outline: $focus-ring;
+}
+button:-moz-focusring {
+    outline: $focus-ring !important;
+}
+.js-focus-visible .focus-visible {
+    outline: $focus-ring;
+}

--- a/web/app/themes/wordpress-scaffold/assets/styles/utility/variables.scss
+++ b/web/app/themes/wordpress-scaffold/assets/styles/utility/variables.scss
@@ -17,12 +17,14 @@ $purple: #7B35FF;
 $primary-color: $purple;
 
 $text-color: $black;
+$focus-color: #649AF5;
 
 /**
  * General stuff
  */
 $border-radius: 2px;
 $box-shadow: 0 0 5px 0 rgba($black, 0.3);
+$focus-ring: 3px solid $focus-color;
 
 /**
  * Fonts

--- a/web/app/themes/wordpress-scaffold/package.json
+++ b/web/app/themes/wordpress-scaffold/package.json
@@ -22,6 +22,7 @@
     "@grrr/utils": "^2.0.1",
     "classlist-polyfill": "^1.2.0",
     "fg-loadjs": "^1.0.0",
+    "focus-visible": "^5.0.2",
     "normalize.css": "^8.0.0",
     "promise-polyfill": "^8.1.0",
     "svg4everybody": "^2.1.8",

--- a/web/app/themes/wordpress-scaffold/templates/partials/newsletter-signup.twig
+++ b/web/app/themes/wordpress-scaffold/templates/partials/newsletter-signup.twig
@@ -9,7 +9,7 @@
     <div style="position: absolute; left: -5000px;" aria-hidden="true">
         <input type="text" name="random_input" tabindex="-1" value="">
     </div>
-    <button type="submit">
+    <button class="button button--white" type="submit">
         {{ __('Sign up', 'grrr') }}
     </button>
     <span role="alert" id="newsletter-signup-alert" aria-hidden="true"></span>

--- a/web/app/themes/wordpress-scaffold/yarn.lock
+++ b/web/app/themes/wordpress-scaffold/yarn.lock
@@ -3417,6 +3417,11 @@ flush-write-stream@^1.0.2:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-visible@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.0.2.tgz#4fae9cf40458b73c10701c9774c462e3ccd53caf"
+  integrity sha512-zT2fj/bmOgEBjqGbURGlowTmCwsIs3bRDMr/sFZz8Ly7VkEiwuCn9swNTL3pPuf8Oua2de7CLuKdnuNajWdDsQ==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"


### PR DESCRIPTION
I've stopped doubling `:hover` states to `:focus` states for a while now in favour of default focus styling (unless it really adds to 'the experience'). But I wasn't really happy with the default `:focus` outlines, especially in Firefox (the really thin dotted border). 

We've also have been battling against those 'stuck' focus states on buttons and toggles, especially on touch. Having to `blur` toggle buttons isn't that great. Plus it really 'blurs' (although the next 'tab re-focus' will stay on the same spot, so not a huge deal). Note that this solution won't prevent 'stuck' `:hover` states.

Anyhow, this PR will...

- Use the default focus styling as fallback if not supported (mainly `no-js`, because polyfilled)
- Use `:focus-visible` or `:-moz-focusring` if supported, or use a tiny polyfill
- It will only apply the styling if the browser says it received 'real focus'
- It does not apply (or get stuck) when clicked by pointer/touch (unless it's a focussed input)
- Allow for really accessible focus styling, without having to resort to JavaScript for detecting how focus was received

Notes:

- Unfortunately support for `:focus-visible` is really limited. I have the 'experimental platform features' flag on, so was really excited that it just worked in Chrome at first. But it doesn't (yet) 😓
- I've added a tiny polyfill, which probably acts more like a global ponyfill since it also seem to supported platforms. So the 'real rules' are there as `no-js` fallback, and for future use/reference.
- I initially added this to the `base` stylesheet, since it's quite important/global. But with all these rules it's also quite a mess, so I've now moved it to a `focus-ring` module (or should it be `focusring`, just like `skiplink`?).

Thoughts on any of this, or the idea in general? 😇

https://github.com/WICG/focus-visible
https://caniuse.com/#feat=css-focus-visible
https://css-tricks.com/almanac/selectors/f/focus-visible/

PS: Note that you can't combine unsupported CSS rules, since browser will not apply any of them if one of them isn't supported. So needed to specify all variations three times...

---

<img width="718" alt="Screenshot 2019-08-30 at 10 15 24" src="https://user-images.githubusercontent.com/1607628/64005163-1abcb200-cb10-11e9-9999-5b17377ac90a.png">

<img width="955" alt="Screenshot 2019-08-30 at 10 15 16" src="https://user-images.githubusercontent.com/1607628/64005164-1abcb200-cb10-11e9-81ec-d55f2f4294ae.png">

<img width="716" alt="Screenshot 2019-08-30 at 10 12 59" src="https://user-images.githubusercontent.com/1607628/64005189-27d9a100-cb10-11e9-857d-4f14591e0c18.png">

<img width="716" alt="Screenshot 2019-08-30 at 10 13 13" src="https://user-images.githubusercontent.com/1607628/64005190-27d9a100-cb10-11e9-8b4f-751a3a6620b8.png">
