### PR TITLE
Disable XML-RPC completely

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -24,6 +24,12 @@
     Deny from all
 </FilesMatch>
 
+# Block all WordPress xmlrpc.php requests
+<Files xmlrpc.php>
+    order deny,allow
+    deny from all
+</Files>
+
 # W3 Total Cache will be added here automagically
 
 # BEGIN WordPress

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Security.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Security.php
@@ -1,0 +1,7 @@
+<?php namespace Grrr\Utils;
+
+/**
+ * Disable XML-RPC.
+ * Note: this is also disabled in the `.htaccess` file.
+ */
+add_filter('xmlrpc_enabled', '__return_false');


### PR DESCRIPTION
I think we're not using any of the functionality nowadays, so let's just disable it?

https://kinsta.com/blog/wordpress-xml-rpc/