### PR TITLE
Add platform indicator to Composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     }
   ],
   "config": {
+    "platform": {
+      "php": "7.1"
+    },
     "preferred-install": "dist",
     "sort-packages": true
   },


### PR DESCRIPTION
I think we should always add the `platform` entry to the Composer config. We've done this before, and it..:

- Simulates the production environment better, given that it is set to the same version (regardless of development environment).
- Makes sure that someone who is using PHP 7.3 locally does not update the lockfile with dependencies which are incompatible with 7.1. The `"php": ">=7.1"` entry only means that 'at least PHP 7.1 is needed'. But it does not make sure that it should 'also run on PHP 7.1'. Limited a max version sounds wrong, so setting a 'target platform' ensure that it will be compatible with whatever the target is.

https://getcomposer.org/doc/06-config.md#platform