### PR TITLE
Move plugin settings to individual classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "wpackagist-plugin/acf-content-analysis-for-yoast-seo": "^2.0",
     "wpackagist-plugin/admin-menu-editor": "^1.6",
     "wpackagist-plugin/amazon-s3-and-cloudfront": "^2.0",
+    "wpackagist-plugin/better-search-replace": "^1.3",
     "wpackagist-plugin/classic-editor": "^1.3",
     "wpackagist-plugin/safe-svg": "^1.9",
     "wpackagist-plugin/timber-library": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf72f8f3263f5e3a13161fcfe83d3655",
+    "content-hash": "75651426a86a9a3b2aab7af37987c9b9",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2091,6 +2091,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/amazon-s3-and-cloudfront/"
+        },
+        {
+            "name": "wpackagist-plugin/better-search-replace",
+            "version": "1.3.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/better-search-replace/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/better-search-replace.zip?timestamp=1557317815"
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/better-search-replace/"
         },
         {
             "name": "wpackagist-plugin/classic-editor",

--- a/web/app/themes/wordpress-scaffold/functions.php
+++ b/web/app/themes/wordpress-scaffold/functions.php
@@ -3,6 +3,7 @@
 use Grrr\Acf;
 use Grrr\Cli;
 use Grrr\Newsletter;
+use Grrr\Plugins;
 use Grrr\PostTypes;
 use Grrr\Shortcodes;
 use Grrr\Taxonomies;
@@ -50,6 +51,11 @@ if (class_exists('acf')) {
  * Shortcodes
  */
 (new Shortcodes\Footnote)->register();
+
+/**
+ * Plugin settings
+ */
+(new Plugins\Yoast)->register();
 
 /**
  * Newsletter

--- a/web/app/themes/wordpress-scaffold/functions.php
+++ b/web/app/themes/wordpress-scaffold/functions.php
@@ -55,6 +55,7 @@ if (class_exists('acf')) {
 /**
  * Plugin settings
  */
+(new Plugins\BetterSearchReplace)->register();
 (new Plugins\Yoast)->register();
 
 /**

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Plugins/BetterSearchReplace.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Plugins/BetterSearchReplace.php
@@ -1,0 +1,22 @@
+<?php namespace Grrr\Plugins;
+
+/**
+ * Adjust settings for Better Search Replace.
+ *
+ * @author Koen Schaft <koen@grrr.nl>
+ */
+final class BetterSearchReplace {
+
+    public function register() {
+        add_filter('bsr_capability', [$this, 'adjust_capability_check']);
+    }
+
+    /**
+     * Overwrite permission config, since this defaults to `install_plugins`.
+     * This capability is turned off for environments other than `development`.
+     */
+    function adjust_capability_check() {
+        return 'manage_options';
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Plugins/Yoast.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Plugins/Yoast.php
@@ -1,0 +1,46 @@
+<?php namespace Grrr\Plugins;
+
+/**
+ * Adjust settings for Yoast (WordPress SEO).
+ *
+ * @author Koen Schaft <koen@grrr.nl>
+ */
+final class Yoast {
+
+    public function register() {
+        add_filter('wpseo_metabox_prio', [$this, 'metabox_prio']);
+        add_action('wpseo_opengraph_image_size', [$this, 'opengraph_image_size'], 10, 2);
+        add_action('template_redirect', [$this, 'remove_comments'], 9999);
+    }
+
+    /**
+     * Move Yoast to bottom in admin.
+     */
+    function metabox_prio() {
+        return 'low';
+    }
+
+    /**
+     * Set the Open Graph image size (default is 'large').
+     * Note that it will not fallback to a default, so uploaded images should be at
+     * least this size or should be upscaled.
+     */
+    public function opengraph_image_size() {
+        return 'image--huge';
+    }
+
+    /**
+     * Remove Yoast comments.
+     */
+    function remove_comments() {
+        if (!class_exists('WPSEO_Frontend')) {
+            return;
+        }
+        $instance = \WPSEO_Frontend::get_instance();
+        if (!method_exists($instance, 'debug_mark')) {
+            return;
+        }
+        remove_action('wpseo_head', [$instance, 'debug_mark'], 2);
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Admin.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Admin.php
@@ -20,11 +20,3 @@ function admin_footer_timing() {
     <?php
 }
 add_action('admin_footer-index.php', __NAMESPACE__ . '\\admin_footer_timing');
-
-/**
- * Move Yoast to bottom.
- */
-function yoasttobottom() {
-    return 'low';
-}
-add_filter('wpseo_metabox_prio', __NAMESPACE__ . '\\yoasttobottom');

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/AdminEditor.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/AdminEditor.php
@@ -84,3 +84,21 @@ function user_can_richedit_custom() {
     return false;
 }
 add_filter('user_can_richedit', __NAMESPACE__ . '\\user_can_richedit_custom');
+
+/**
+ * Set default image embed options for WYSIWYG.
+ * See: https://core.trac.wordpress.org/ticket/35101
+ */
+function reset_image_insert_settings() {
+  ?>
+    <script>
+      if (typeof setUserSetting !== 'undefined') {
+        setUserSetting('imgsize', 'large'); // thumbnail || medium || large || full
+        setUserSetting('align', 'none'); // none || left || center || right
+        setUserSetting('urlbutton', 'none'); // none || file || post
+      }
+    </script>
+  <?php
+}
+add_action('admin_head-post.php', __NAMESPACE__ . '\\reset_image_insert_settings');
+add_action('admin_head-post-new.php', __NAMESPACE__ . '\\reset_image_insert_settings');

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Cleanup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Cleanup.php
@@ -37,19 +37,3 @@ function disable_w3tc_comment($can_print_comment) {
     return current_user_can('activate_plugins');
 }
 add_filter('w3tc_can_print_comment', __NAMESPACE__ . '\\disable_w3tc_comment');
-
-/**
- * Disable Yoast's Hidden love letter about using the WordPress SEO plugin.
- */
-function remove_yoast_comment() {
-    if (!class_exists('WPSEO_Frontend')) {
-        return;
-    }
-    $instance = \WPSEO_Frontend::get_instance();
-    if (!method_exists($instance, 'debug_mark')) {
-        return ;
-    }
-    remove_action('wpseo_head', [$instance, 'debug_mark'], 2);
-};
-
-add_action('template_redirect', __NAMESPACE__ . '\\remove_yoast_comment', 9999);

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Extras.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/Extras.php
@@ -51,32 +51,6 @@ function set_max_srcset(int $max, array $sizes) {
 add_filter('max_srcset_image_width', __NAMESPACE__ . '\\set_max_srcset', 10, 2);
 
 /**
- * Set the Open Graph image size (else will use native 'Large' from WordPress).
- */
-function yoast_og_size() {
-    return 'image--huge';
-}
-add_filter('wpseo_opengraph_image_size', __NAMESPACE__ . '\\yoast_og_size', 10, 2);
-
-/**
- * Set default image embed options for WYSIWYG.
- * See: https://core.trac.wordpress.org/ticket/35101
- */
-function reset_image_insert_settings() {
-  ?>
-    <script>
-      if ( typeof setUserSetting !== 'undefined' ) {
-        setUserSetting('imgsize', 'large'); // thumbnail || medium || large || full
-        setUserSetting('align', 'none'); // none || left || center || right
-        setUserSetting('urlbutton', 'none'); // none || file || post
-      }
-    </script>
-  <?php
-}
-add_action('admin_head-post.php', __NAMESPACE__ . '\\reset_image_insert_settings');
-add_action('admin_head-post-new.php', __NAMESPACE__ . '\\reset_image_insert_settings');
-
-/**
  * Adjust embed size defaults.
  */
 function embed_defaults($embed_size){


### PR DESCRIPTION
I think we discussed this recently. Main point is to clean up the 'utils' a bit, and have stuff a proper scope.

- Add a `Plugins` namespace. 
- Move Yoast settings to it's own class. Would like to replace that plugin itself, but there's an issue open for to do so.
- Add Better Search Replace plugin, since it's being used in all new projects.

I've left W3TC settings in place, since that will be removed shortly anyway. Plus a SimplyStaticDeploy class will follow as well.