### PR TITLE
Refactor PostType registration and add structured data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "roots/soil": "^3.7",
     "roots/wp-password-bcrypt": "^1.0.0",
     "sentry/sdk": "^2.0",
+    "spatie/schema-org": "^2.7",
     "vlucas/phpdotenv": "^4.0.0",
     "wikimedia/composer-merge-plugin": "^1.4",
     "wpackagist-plugin/acf-content-analysis-for-yoast-seo": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35ce891cc971ba28b5b29d0595ed81c4",
+    "content-hash": "9761636e714bb8eaaf43ac05af2e35b7",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -2135,6 +2135,66 @@
                 }
             ],
             "time": "2020-05-20T20:49:38+00:00"
+        },
+        {
+            "name": "spatie/schema-org",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/schema-org.git",
+                "reference": "d8d03a78e8ad2bc4fcda760eca0b1b543c8d71f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/schema-org/zipball/d8d03a78e8ad2bc4fcda760eca0b1b543c8d71f7",
+                "reference": "d8d03a78e8ad2bc4fcda760eca0b1b543c8d71f7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "graham-campbell/analyzer": "^2.1.1",
+                "league/flysystem": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0",
+                "scrutinizer/ocular": "^1.5",
+                "symfony/console": "^3.2",
+                "symfony/css-selector": "^3.2",
+                "symfony/dom-crawler": "^3.2",
+                "twig/twig": "^1.28"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\SchemaOrg\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fluent builder Schema.org types and ld+json generator",
+            "homepage": "https://github.com/spatie/schema-org",
+            "keywords": [
+                "schema-org",
+                "spatie"
+            ],
+            "time": "2019-10-06T13:17:19+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/web/app/themes/wordpress-scaffold/functions.php
+++ b/web/app/themes/wordpress-scaffold/functions.php
@@ -4,7 +4,7 @@ use Grrr\Acf;
 use Grrr\Cli;
 use Grrr\Newsletter;
 use Grrr\Plugins;
-use Grrr\PostTypes;
+use Grrr\PostTypes\PostTypeRegistry;
 use Grrr\Shortcodes;
 use Grrr\Taxonomies;
 use Grrr\Theme;
@@ -42,10 +42,7 @@ if (class_exists('acf')) {
 /**
  * Post Types
  */
-(new PostTypes\Comment)->register();
-(new PostTypes\Post)->register();
-(new PostTypes\Page)->register();
-(new PostTypes\Example)->register();
+PostTypeRegistry::register();
 
 /**
  * Shortcodes

--- a/web/app/themes/wordpress-scaffold/functions.php
+++ b/web/app/themes/wordpress-scaffold/functions.php
@@ -24,7 +24,7 @@ if (class_exists('Timber')) {
     (new Twig\Filters)->register();
     (new Twig\Functions)->register();
 } else {
-    (new Theme\NoTimber)->register();
+    (new Utils\NoTimber)->register();
 }
 
 /**

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Config.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Config.php
@@ -8,6 +8,7 @@ final class Config {
     const POST_TYPES = [
         'comment' => 'Comment',
         'example' => 'Example',
+        'faq'     => 'Faq',
         'page'    => 'Page',
         'post'    => 'Post',
     ];

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Config.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Config.php
@@ -1,0 +1,26 @@
+<?php namespace Grrr;
+
+final class Config {
+
+    /**
+     * Mapping of post type names to their class names.
+     */
+    const POST_TYPES = [
+        'comment' => 'Comment',
+        'example' => 'Example',
+        'page'    => 'Page',
+        'post'    => 'Post',
+    ];
+
+    /**
+     * All custom REST routes.
+     * See also `Rest\Routes` and `Utils\Security`.
+     */
+    const REST = [
+        'namespace' => 'grrr/v1',
+        'routes' => [
+            'newsletter' => 'newsletter/subscribe',
+        ],
+    ];
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Comment.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Comment.php
@@ -1,6 +1,6 @@
 <?php namespace Grrr\PostTypes;
 
-class Comment {
+class Comment extends PostTypeStub {
 
     protected $type = 'comment';
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Faq.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Faq.php
@@ -1,0 +1,35 @@
+<?php namespace Grrr\PostTypes;
+
+use Spatie\SchemaOrg\Schema;
+use Timber;
+
+class Faq extends PostTypeAbstract {
+
+    protected $type = 'faq';
+    protected $slug = 'faq';
+    protected $icon = 'dashicons-editor-help';
+
+    protected $labels = [
+        'name' => 'FAQs',
+        'singular_name' => 'FAQ',
+    ];
+
+    protected $args = [
+        'public' => true,
+        'has_archive' => true,
+        'supports' => [
+            'title',
+            'revisions',
+        ],
+    ];
+
+    public function get_structured_data(Timber\Post $post, bool $asArray = false) {
+        $answer = Schema::Answer()->text($post->meta('answer') ?: '');
+        $question = Schema::Question()->name($post->title)->acceptedAnswer($answer);
+        $data = Schema::FAQPage()->mainEntity($question);
+        return $asArray
+            ? $data->toArray()
+            : $data->toScript();
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Page.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Page.php
@@ -1,6 +1,6 @@
 <?php namespace Grrr\PostTypes;
 
-class Page {
+class Page extends PostTypeStub {
 
     protected $type = 'page';
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Post.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/Post.php
@@ -1,6 +1,6 @@
 <?php namespace Grrr\PostTypes;
 
-class Post {
+class Post extends PostTypeStub {
 
     protected $type = 'post';
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeAbstract.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeAbstract.php
@@ -1,12 +1,12 @@
 <?php namespace Grrr\PostTypes;
 
 use Garp\Functional as f;
-use Grrr\Timber as GrrrTimber;
+use Grrr\Timber\TimberPostBase;
 use Spatie\SchemaOrg\Schema;
 use Timber;
 use Twig_Environment;
 
-abstract class PostTypeAbstract {
+abstract class PostTypeAbstract extends PostTypeStub {
 
     protected $type;
     protected $slug;
@@ -55,16 +55,12 @@ abstract class PostTypeAbstract {
                 'post_type' => $this->type,
                 'posts_per_page' => $amount,
             ],
-            GrrrTimber\TimberPostBase::class
+            TimberPostBase::class
         );
     }
 
     public function get_archive_link() {
         return get_post_type_archive_link($this->type);
-    }
-
-    public function get_structured_data(Timber\Post $post, bool $asArray = false) {
-        return $asArray ? [] : '';
     }
 
 }

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeAbstract.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeAbstract.php
@@ -1,7 +1,10 @@
 <?php namespace Grrr\PostTypes;
 
-use Timber;
 use Garp\Functional as f;
+use Grrr\Timber as GrrrTimber;
+use Spatie\SchemaOrg\Schema;
+use Timber;
+use Twig_Environment;
 
 abstract class PostTypeAbstract {
 
@@ -40,7 +43,6 @@ abstract class PostTypeAbstract {
 
     public function register() {
         add_action('init', [$this, 'register_post_type'], 1);
-        add_filter('timber/twig', [$this, 'twig_functions']);
     }
 
     public function register_post_type() {
@@ -48,22 +50,21 @@ abstract class PostTypeAbstract {
     }
 
     public function get_posts(int $amount = -1) {
-        return Timber\Timber::get_posts([
-            'post_type' => $this->type,
-            'posts_per_page' => $amount,
-        ]);
+        return Timber\Timber::get_posts(
+            [
+                'post_type' => $this->type,
+                'posts_per_page' => $amount,
+            ],
+            GrrrTimber\TimberPostBase::class
+        );
     }
 
     public function get_archive_link() {
         return get_post_type_archive_link($this->type);
     }
 
-    public function twig_functions(\Twig_Environment $twig) {
-        $type = str_replace('-', '_', $this->type);
-        $twig->addFunction(
-            new Timber\Twig_Function('get_' . $type . '_posts', [$this, 'get_posts'])
-        );
-        return $twig;
+    public function get_structured_data(Timber\Post $post, bool $asArray = false) {
+        return $asArray ? [] : '';
     }
 
 }

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
@@ -2,7 +2,7 @@
 
 use Grrr\PostTypes\PostTypeAbstract;
 use Garp\Functional as f;
-use Grrr\Config;
+use Grrr\Theme\Config;
 
 final class PostTypeRegistry {
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
@@ -1,0 +1,31 @@
+<?php namespace Grrr\PostTypes;
+
+use Grrr\PostTypes\PostTypeAbstract;
+use Garp\Functional as f;
+use Grrr\Config;
+
+final class PostTypeRegistry {
+
+    const NAMESPACE = '\\Grrr\\PostTypes\\';
+
+    public static function register() {
+        foreach (Config::POST_TYPES as $name => $className) {
+            $classFull = static::compose_full_class($className);
+            (new $classFull)->register();
+        }
+    }
+
+    public static function create_class(string $name) {
+        $class =  static::get_class($name);
+        return new $class();
+    }
+
+    public static function get_class(string $name): string {
+        return static::compose_full_class(f\prop($name, Config::POST_TYPES));
+    }
+
+    protected static function compose_full_class(string $class): string {
+        return __NAMESPACE__ . '\\' . $class;
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeRegistry.php
@@ -6,8 +6,6 @@ use Grrr\Config;
 
 final class PostTypeRegistry {
 
-    const NAMESPACE = '\\Grrr\\PostTypes\\';
-
     public static function register() {
         foreach (Config::POST_TYPES as $name => $className) {
             $classFull = static::compose_full_class($className);

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeStub.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/PostTypes/PostTypeStub.php
@@ -1,0 +1,11 @@
+<?php namespace Grrr\PostTypes;
+
+use Timber;
+
+abstract class PostTypeStub {
+
+    public function get_structured_data(Timber\Post $post, bool $asArray = false) {
+        return $asArray ? [] : '';
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Rest/Routes.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Rest/Routes.php
@@ -1,14 +1,9 @@
 <?php namespace Grrr\Rest;
 
 use Garp\Functional as f;
+use Grrr\Config;
 
 class Routes {
-
-    const NAMESPACE = 'grrr/v1';
-
-    const ROUTES = [
-        'newsletter' => 'newsletter/subscribe',
-    ];
 
     public static function get(string $name): string {
         return f\prop($name, static::ROUTES);
@@ -17,14 +12,14 @@ class Routes {
     public static function get_all(bool $full = true): array {
         return f\reduce(function($acc, $route) use ($full) {
             $acc[] = $full
-                ? '/' . static::NAMESPACE . '/' . $route
+                ? '/' . f\prop('namespace', Config::REST) . '/' . $route
                 : $route;
             return $acc;
-        }, [], static::ROUTES);
+        }, [], f\prop('routes', Config::REST));
     }
 
     public static function url(string $name): string {
-        return rest_url(static::NAMESPACE . '/' . static::get($name));
+        return rest_url(f\prop('namespace', Config::REST) . '/' . static::get($name));
     }
 
 }

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Rest/Routes.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Rest/Routes.php
@@ -1,7 +1,7 @@
 <?php namespace Grrr\Rest;
 
 use Garp\Functional as f;
-use Grrr\Config;
+use Grrr\Theme\Config;
 
 class Routes {
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
@@ -14,13 +14,31 @@ final class Config {
     ];
 
     /**
-     * All custom REST routes.
+     * Custom REST routes.
      * See also `Rest\Routes` and `Utils\Security`.
      */
     const REST = [
         'namespace' => 'grrr/v1',
         'routes' => [
             'newsletter' => 'newsletter/subscribe',
+        ],
+    ];
+
+    /**
+     * Navigation menus.
+     */
+    const NAV_MENUS = [
+        [
+            'location' => 'primary_navigation',
+            'description' => 'Primary Navigation',
+        ],
+        [
+            'location' => 'footer_primary_navigation',
+            'description' => 'Footer Primary Navigation',
+        ],
+        [
+            'location' => 'footer_secondary_navigation',
+            'description' => 'Footer Secondary Navigation',
         ],
     ];
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
@@ -3,7 +3,7 @@
 final class Config {
 
     /**
-     * Mapping of post type names to their class names.
+     * Post type registration names and their class names.
      */
     const POST_TYPES = [
         'comment' => 'Comment',
@@ -14,14 +14,24 @@ final class Config {
     ];
 
     /**
-     * Custom REST routes.
-     * See also `Rest\Routes` and `Utils\Security`.
+     * Image sizes.
      */
-    const REST = [
-        'namespace' => 'grrr/v1',
-        'routes' => [
-            'newsletter' => 'newsletter/subscribe',
-        ],
+    const IMAGE_SIZES = [
+
+        // Regular images
+        ['image--tiny', 640, 0, false],
+        ['image--small', 960, 0, false],
+        ['image--medium', 1280, 0, false],
+        ['image--large', 1920, 0, false],
+        ['image--huge', 2560, 0, false],
+
+        // Cropped images
+        ['image-cropped--tiny', 640, 360, true],
+        ['image-cropped--small', 960, 540, true],
+        ['image-cropped--medium', 1280, 720, true],
+        ['image-cropped--large', 1920, 1280, true],
+        ['image-cropped--huge', 2560, 1440, true],
+
     ];
 
     /**
@@ -39,6 +49,17 @@ final class Config {
         [
             'location' => 'footer_secondary_navigation',
             'description' => 'Footer Secondary Navigation',
+        ],
+    ];
+
+    /**
+     * Custom REST routes.
+     * See also `Rest\Routes` and `Utils\Security`.
+     */
+    const REST = [
+        'namespace' => 'grrr/v1',
+        'routes' => [
+            'newsletter' => 'newsletter/subscribe',
         ],
     ];
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Config.php
@@ -1,4 +1,4 @@
-<?php namespace Grrr;
+<?php namespace Grrr\Theme;
 
 final class Config {
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Setup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Setup.php
@@ -15,21 +15,6 @@ if (WP_ENV !== 'development') {
 
 class Setup extends Timber\Site {
 
-    const NAV_MENUS = [
-        [
-            'location' => 'primary_navigation',
-            'description' => 'Primary Navigation',
-        ],
-        [
-            'location' => 'footer_primary_navigation',
-            'description' => 'Footer Primary Navigation',
-        ],
-        [
-            'location' => 'footer_secondary_navigation',
-            'description' => 'Footer Secondary Navigation',
-        ],
-    ];
-
     public function __construct() {
         parent::__construct();
     }
@@ -48,11 +33,12 @@ class Setup extends Timber\Site {
         $context['site'] = $this;
 
         // Add menus to context, but check if menu for location exists.
-        $context['menus'] = f\reduce(function ($menus, $nav_menu) {
-            $menus[$nav_menu['location']] = has_nav_menu($nav_menu['location'])
-                ? new Timber\Menu($nav_menu['location']) : null;
+        $context['menus'] = f\reduce(function ($menus, $menu) {
+            $menus[$menu['location']] = has_nav_menu($menu['location'])
+                ? new Timber\Menu($menu['location'])
+                : null;
             return $menus;
-        }, [], self::NAV_MENUS);
+        }, [], Config::NAV_MENUS);
 
         return $context;
     }
@@ -79,7 +65,7 @@ class Setup extends Timber\Site {
 
         // Register wp_nav_menu() menus
         // http://codex.wordpress.org/Function_Reference/register_nav_menus
-        $this->_register_nav_menus();
+        $this->register_nav_menus(Config::NAV_MENUS);
 
         // Enable post thumbnails
         // http://codex.wordpress.org/Post_Thumbnails
@@ -132,12 +118,12 @@ class Setup extends Timber\Site {
     /**
      * Nav menus.
      */
-    protected function _register_nav_menus() {
+    protected function register_nav_menus(array $menus) {
         f\map(
-            function ($nav_menu) {
-                register_nav_menu($nav_menu['location'], $nav_menu['description']);
+            function ($menu) {
+                register_nav_menu($menu['location'], $menu['description']);
             },
-            self::NAV_MENUS
+            $menus
         );
     }
 

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Setup.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Theme/Setup.php
@@ -73,18 +73,10 @@ class Setup extends Timber\Site {
         // http://codex.wordpress.org/Function_Reference/add_image_size
         add_theme_support('post-thumbnails');
 
-        // Image scaling templates
-        add_image_size('image--tiny', 640, 0, false);
-        add_image_size('image--small', 960, 0, false);
-        add_image_size('image--medium', 1280, 0, false);
-        add_image_size('image--large', 1920, 0, false);
-        add_image_size('image--huge', 2560, 0, false);
-
-        add_image_size('image-cropped--tiny', 640, 360, true);
-        add_image_size('image-cropped--small', 960, 540, true);
-        add_image_size('image-cropped--medium', 1280, 720, true);
-        add_image_size('image-cropped--large', 1920, 1280, true);
-        add_image_size('image-cropped--huge', 2560, 1440, true);
+        // Register custom image sizes.
+        foreach (Config::IMAGE_SIZES as $entry) {
+            add_image_size(...$entry);
+        }
 
         // Enable HTML5 markup support
         // http://codex.wordpress.org/Function_Reference/add_theme_support#HTML5

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Timber/TimberPostBase.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Timber/TimberPostBase.php
@@ -7,7 +7,7 @@ use WP_Post;
 
 class TimberPostBase extends Timber\Post {
 
-    protected $postId;
+    protected $post;
 
     public function __construct(?WP_Post $post = null) {
         $this->post = $post;
@@ -16,7 +16,7 @@ class TimberPostBase extends Timber\Post {
 
     public function structured_data(...$args) {
         return PostTypeRegistry::create_class($this->post->post_type)
-            ->get_structured_data(new Timber\Post($this->post), ...$args);
+            ->get_structured_data(new static($this->post), ...$args);
     }
 
 }

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Timber/TimberPostBase.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Timber/TimberPostBase.php
@@ -1,0 +1,22 @@
+<?php namespace Grrr\Timber;
+
+use Garp\Functional as f;
+use Grrr\PostTypes\PostTypeRegistry;
+use Timber;
+use WP_Post;
+
+class TimberPostBase extends Timber\Post {
+
+    protected $postId;
+
+    public function __construct(?WP_Post $post = null) {
+        $this->post = $post;
+        parent::__construct($post);
+    }
+
+    public function structured_data(...$args) {
+        return PostTypeRegistry::create_class($this->post->post_type)
+            ->get_structured_data(new Timber\Post($this->post), ...$args);
+    }
+
+}

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Twig/Functions.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Twig/Functions.php
@@ -1,26 +1,33 @@
 <?php namespace Grrr\Twig;
 
-use Timber;
+use Garp\Functional as f;
+use Grrr\PostTypes\PostTypeRegistry;
 use Grrr\Theme;
 use Grrr\Utils;
 use Grrr\Utils\Assets;
-use Garp\Functional as f;
+use Timber;
 
 class Functions {
 
     const FUNCTION_MAPPER = [
+        'archive_link'      => 'get_archive_link',
         'asset'             => 'get_asset_path',
         'env'               => 'get_env',
-        'archive_link'      => 'get_archive_link',
         'option'            => 'get_acf_option',
         'page'              => 'get_acf_page',
+        'posts'             => 'get_posts',
         'snippet'           => 'get_acf_snippet',
         'source'            => 'get_source',
+        'structured_data'   => 'get_structured_data',
         'svg'               => 'get_svg',
     ];
 
     public function register() {
         add_filter('timber/twig', [$this, 'add_functions']);
+    }
+
+    public function get_archive_link(string $postType) {
+        return get_post_type_archive_link($postType);
     }
 
     public function get_asset_path(string $filepath) {
@@ -52,12 +59,18 @@ class Functions {
         return get_field(str_replace(' ', '_', "pages_{$name}"), 'option');
     }
 
-    public function get_archive_link(string $postType) {
-        return get_post_type_archive_link($postType);
+    public function get_posts(string $type, ...$args) {
+        $class = PostTypeRegistry::create_class($type)
+            ->get_posts(...$args);
     }
 
     public function get_source(string $filepath) {
         return file_get_contents(Assets\asset_path($filepath, false));
+    }
+
+    public function get_structured_data(Timber\Post $post, ...$args) {
+        return PostTypeRegistry::create_class($post->type)
+            ->get_structured_data($post, ...$args);
     }
 
     public function get_svg(string $id, array $arguments = []) {

--- a/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/NoTimber.php
+++ b/web/app/themes/wordpress-scaffold/lib/Grrr/Utils/NoTimber.php
@@ -1,6 +1,6 @@
 <?php namespace Grrr\Theme;
 
-class NoTimber {
+final class NoTimber {
 
     public function register() {
     	add_action('admin_notices', [$this, 'show_admin_notice']);

--- a/web/app/themes/wordpress-scaffold/templates/single.twig
+++ b/web/app/themes/wordpress-scaffold/templates/single.twig
@@ -16,3 +16,8 @@
     {{ post.content }}
 
 </article>
+
+{#
+ # Render structured data if available.
+ #}
+{{ structured_data(post)|raw }}


### PR DESCRIPTION
- Adds a more global `Config` for import constants.
- Moved the most notable items to the new `Config`.
- Adds `PostTypeRegistration` to register post types in one place and have a (non-magic) proper mapping from type/name to class. Unfortunately the type/name is still required, since it's also needed when the classes are constructed. 
- Adds the `Faq` post type, without any templates for now.


To get structured data (will never fail):

```twig
<!-- script -->
{{ post.structured_data|raw }}
{{ structured_data(post)|raw }}

<!-- array -->
{{ post.structured_data(true)|json_encode|raw }}
{{ structured_data(post, true)|json_encode|raw }}
```

Bonus:

```twig
<!-- old -->
{{ get_example_posts() }}

<!-- new -->
{{ posts('example') }}
```