### PR TITLE
Disable common admin emails for non-production environments

### DIFF
--- a/web/app/mu-plugins/disable-admin-mails.php
+++ b/web/app/mu-plugins/disable-admin-mails.php
@@ -1,0 +1,16 @@
+<?php
+/*
+Plugin Name:  Disable Admin Mails
+Plugin URI:   https://grrr.nl/
+Description:  Disable common admin mails for non-production environments.
+Version:      1.0.0
+Author:       GRRR
+Author URI:   https://grrr.nl/
+License:      MIT License
+*/
+
+if (WP_ENV !== 'production') {
+    add_filter('wp_new_user_notification_email_admin', '__return_false');
+    add_filter('wp_password_change_notification_email', '__return_false');
+    add_filter('send_site_admin_email_change_email', '__return_false');
+}


### PR DESCRIPTION
This disables all global admin emails for 'new user', 'password changed' and 'site admin email requested/changed'. This should still send out the mails to the requester or the one who should take action, but not to the global site admin. 

Hopefully prevents sending more local/testing emails. I've left it on for production.

- Good idea?
- I placed this in a MU-plugin for now, since there's also the `disallow-indexing.php` one. But a lot of stuff like this is also place in the `Utils\` namespace. Thoughts/preferences?
- Should we base this on `WP_ENV`? Something like `ALLOW_ADMIN_EMAILS` is less implicit, but I'm not sure if it's something you'd really would like to control (and people forget stuff in the `.env`s all the time...).
