### PR TITLE
Add new nudge button @grrr/cookie-consent options

### DIFF
--- a/web/app/themes/wordpress-scaffold/acf-json/group_5c8289813874e.json
+++ b/web/app/themes/wordpress-scaffold/acf-json/group_5c8289813874e.json
@@ -133,11 +133,62 @@
             "delay": 0
         },
         {
-            "key": "field_5c8289d44ce14",
+            "key": "field_5ece8ab6e5b58",
             "label": "Button",
-            "name": "cookie_consent_button",
-            "type": "text",
+            "name": "",
+            "type": "tab",
             "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5d7385acd7dfb",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "left",
+            "endpoint": 0
+        },
+        {
+            "key": "field_5ece8abfda2ca",
+            "label": "Accept All",
+            "name": "cookie_consent_accept_all",
+            "type": "true_false",
+            "instructions": "The initial button will act as an 'accept all' button. This only happens when no preferences have been stored, and nudges users to accept all cookies.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5d7385acd7dfb",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 1,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_5c8289d44ce14",
+            "label": "Button (default)",
+            "name": "cookie_consent_button_default",
+            "type": "text",
+            "instructions": "The default button label. Shown when 'accept all' is not enabled, or when existing preferences are found (e.g. opening the dialog in a later stage).",
             "required": 1,
             "conditional_logic": 0,
             "wrapper": {
@@ -145,7 +196,26 @@
                 "class": "",
                 "id": ""
             },
-            "default_value": "Ok",
+            "default_value": "Save preferences",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5ece8aea1bba2",
+            "label": "Button (accept all)",
+            "name": "cookie_consent_button_accept_all",
+            "type": "text",
+            "instructions": "Button label shown when 'accept all' is enabled and no preferences have been stored.",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Accept all cookies",
             "placeholder": "",
             "prepend": "",
             "append": "",
@@ -325,5 +395,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1587628922
+    "modified": 1590595170
 }

--- a/web/app/themes/wordpress-scaffold/assets/scripts/modules/cookie-consent.js
+++ b/web/app/themes/wordpress-scaffold/assets/scripts/modules/cookie-consent.js
@@ -8,10 +8,19 @@ export default () => {
 
   // Update Tag Manager when `update` event is fired.
   cookieConsent.on('update', cookies => {
+
+    // Example 1: Fire for all accepted cookie types.
     cookies.filter(cookie => cookie.accepted).forEach(cookie => pushEvent({
       event: 'cookieConsent',
       cookieType: cookie.id,
     }));
+
+    // Example 2: Fire only the selected cookie type (e.g. when used with radio buttons).
+    pushEvent({
+      event: 'cookieConsent',
+      cookieConsent: cookies.find(cookie => cookie.accepted).id,
+    });
+
   });
 
   // Make the object globally available.

--- a/web/app/themes/wordpress-scaffold/assets/scripts/modules/cookie-consent.js
+++ b/web/app/themes/wordpress-scaffold/assets/scripts/modules/cookie-consent.js
@@ -3,8 +3,12 @@ import { pushEvent } from './gtm-event';
 
 export default () => {
 
-  // Construct and initialize the module.
-  const cookieConsent = CookieConsent(window.COOKIE_CONSENT_CONFIG);
+  // Construct and initialize the module if a config is found.
+  const config = window.COOKIE_CONSENT_CONFIG;
+  if (!config) {
+    return;
+  }
+  const cookieConsent = new CookieConsent(config);
 
   // Update Tag Manager when `update` event is fired.
   cookieConsent.on('update', cookies => {

--- a/web/app/themes/wordpress-scaffold/package.json
+++ b/web/app/themes/wordpress-scaffold/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@grrr/cookie-consent": "^0.2.0",
+    "@grrr/cookie-consent": "^1.0.0",
     "@grrr/hansel": "^2.0.0",
     "@grrr/ready": "^0.1.0",
     "@grrr/utils": "^2.0.1",

--- a/web/app/themes/wordpress-scaffold/templates/partials/cookie-consent.twig
+++ b/web/app/themes/wordpress-scaffold/templates/partials/cookie-consent.twig
@@ -3,10 +3,14 @@
 <script>
     window.COOKIE_CONSENT_CONFIG = {
       type: '{{ type|e('js') }}',
+      acceptAllButton: {{ option('accept all', 'cookie consent') ? 'true' : 'false' }},
       labels: {
         title: '{{ option('title', 'cookie consent')|e('js') }}',
         description: '{{ option('description', 'cookie consent')|e('js') }}',
-        button: '{{ option('button', 'cookie consent')|e('js') }}',
+        button: {
+          default: '{{ option('button default', 'cookie consent')|e('js') }}',
+          acceptAll: '{{ option('button accept all', 'cookie consent')|e('js') }}',
+        },
       },
       cookies: [
         {% for cookie in option('cookies', 'cookie consent') %}

--- a/web/app/themes/wordpress-scaffold/yarn.lock
+++ b/web/app/themes/wordpress-scaffold/yarn.lock
@@ -808,17 +808,17 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@grrr/cookie-consent@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@grrr/cookie-consent/-/cookie-consent-0.2.0.tgz#c18de8e40358eb1e078d0c53c3afd5a781357123"
-  integrity sha512-00mYVL8VbRIxQsGUzZt4v+BmXEqP/dxk9noSZN5qz2nWImcEVvAwzXe/dQyAhRbvbpD1ahB95oVD6REPUCzo3Q==
+"@grrr/cookie-consent@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@grrr/cookie-consent/-/cookie-consent-1.0.0.tgz#2192284f59db4d752fe2f38270656d2fbdd5ed2a"
+  integrity sha512-A0vUOkPLTvlWrNU1DufoFkw56oRya2eQEfD8iLRSy9ghKyShKIPmigrY6LwgY3en/5CCkHkaF6uGyJUO23M7Eg==
   dependencies:
     "@grrr/utils" "^2.3.0"
 
 "@grrr/gulpfile@^7.0.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@grrr/gulpfile/-/gulpfile-7.3.1.tgz#e1a188955b19fe43f5f2acd48581b63409cf92a8"
-  integrity sha512-oBejN68QTqaGRjh5Cx8s+2V//i5xezxhZCNI0CZ6RCsBt1x2G3MBzbTzYjD2eWIyInkYnCiJ0vYvSWLMS5FxVg==
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@grrr/gulpfile/-/gulpfile-7.3.0.tgz#88932d23400611aee3b9b4be4ef558b672d754ac"
+  integrity sha512-XtUsAXAPLDDkdgtSNFWt7If1KToDdSPwY2R9XAMZagi5tMmE4NBXE4SHLJlS/EIr7wrgB2d6mBlK/m63BDKzYw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"


### PR DESCRIPTION
Adds a new option for an 'Accept all cookies' button. Works for both `checkbox` and `radio` inputs, and is fully configurable via the ACF options page.